### PR TITLE
Css changes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,7 +80,7 @@ module.exports = async function config() {
       ({
         docs: {
           sidebar: {
-            hideable: false,
+            hideable: true,
             autoCollapseCategories: false,
           },
         },

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -130,3 +130,10 @@
 
 }
 
+.ch-inline-code>code {
+  word-break: break-word;
+}
+
+.ch-scrollycoding-sticker {
+  flex: 1.5;
+}


### PR DESCRIPTION
word wrap (so blocks don't overflow into toc)
and flex ratio (left= 1: right=1.5)